### PR TITLE
Replace "ColumnContextMenu_onClick" with "ColumnContextMenu_onRelease"

### DIFF
--- a/src/gtk/GtkTorrentTreeView.cpp
+++ b/src/gtk/GtkTorrentTreeView.cpp
@@ -52,9 +52,10 @@ bool GtkTorrentTreeView::torrentView_onClick(GdkEventButton *event)
 	return false;
 }
 
-bool GtkTorrentTreeView::ColumnContextMenu_onClick(GdkEventButton *event, Gtk::TreeViewColumn *tvc)
+bool GtkTorrentTreeView::ColumnContextMenu_onRelease(GdkEventButton *event, Gtk::TreeViewColumn *tvc)
 {
 	tvc->set_visible(!tvc->get_visible());
+	m_rcMenu->hide();
 	return true;
 }
 
@@ -67,7 +68,7 @@ bool GtkTorrentTreeView::torrentColumns_onClick(GdkEventButton *event)
                 {
                         Gtk::CheckMenuItem *rcmItem1 = Gtk::manage(new Gtk::CheckMenuItem(c->get_title()));
                         rcmItem1->set_active(c->get_visible());
-                        rcmItem1->signal_button_press_event().connect(sigc::bind<1>(sigc::mem_fun(*this, &GtkTorrentTreeView::ColumnContextMenu_onClick), c));
+                        rcmItem1->signal_button_release_event().connect(sigc::bind<1>(sigc::mem_fun(*this, &GtkTorrentTreeView::ColumnContextMenu_onRelease), c));
                         m_rcMenu->add(*rcmItem1);
                 }
 

--- a/src/gtk/GtkTorrentTreeView.hpp
+++ b/src/gtk/GtkTorrentTreeView.hpp
@@ -63,9 +63,9 @@ private:
 	vector<unsigned> selectedIndices();
 
 	/* Event handlers for clicks on the controls */
-	bool       torrentView_onClick(GdkEventButton *event);
-	bool    torrentColumns_onClick(GdkEventButton *event);
-	bool ColumnContextMenu_onClick(GdkEventButton *event, Gtk::TreeViewColumn *tvc);
+	bool         torrentView_onClick(GdkEventButton *event);
+	bool      torrentColumns_onClick(GdkEventButton *event);
+	bool ColumnContextMenu_onRelease(GdkEventButton *event, Gtk::TreeViewColumn *tvc);
 
 	/* Event handlers for the torrent view context menu */
 	void     stopView_onClick();


### PR DESCRIPTION
Just a personal preference, but I think this feels nicer and more consistent with other applications to execute the action on mouse release, after the context menu has gone away.
