### PR TITLE
Added Notebook to GTKTorrentInfoBar

### DIFF
--- a/src/gtk/GtkTorrentInfoBar.cpp
+++ b/src/gtk/GtkTorrentInfoBar.cpp
@@ -6,14 +6,20 @@ GtkTorrentInfoBar::GtkTorrentInfoBar()
 	: Gtk::Box(Gtk::ORIENTATION_VERTICAL)
 {
 	//TODO: better layout
+	m_notebook = Gtk::manage(new Gtk::Notebook());
+
 	m_title = Gtk::manage(new Gtk::Label());
 	this->pack_start(*m_title);
-
+	
 	m_progress = Gtk::manage(new GtkBlockBar());
-	this->pack_start(*m_progress);
+	this->pack_start(*m_notebook);
 
 	m_graph = Gtk::manage(new GtkGraph());
-	this->pack_end(*m_graph, Gtk::PACK_EXPAND_WIDGET, 5);
+	//this->pack_end(*m_graph, Gtk::PACK_EXPAND_WIDGET, 5);
+
+	m_notebook->append_page(*m_graph, "Info Graph");
+	m_notebook->append_page(*m_torrent_info, "Torrent Info");
+	this->pack_end(*m_notebook, Gtk::PACK_EXPAND_WIDGET, 5);
 }
 
 void GtkTorrentInfoBar::updateInfo(shared_ptr<gt::Torrent> selected)

--- a/src/gtk/GtkTorrentInfoBar.hpp
+++ b/src/gtk/GtkTorrentInfoBar.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <gtkmm/box.h>
+#include <gtkmm/notebook.h>
 #include <gtorrent/Torrent.hpp>
 #include "GtkBlockBar.hpp"
 #include "GtkGraph.hpp"
@@ -11,6 +12,7 @@ private:
 	GtkBlockBar *m_progress;
 	Gtk::Label *m_title;
 	GtkGraph *m_graph;
+	Gtk::Notebook *m_notebook;
 public:
 	GtkTorrentInfoBar();
 	void updateInfo(shared_ptr<gt::Torrent> selected);


### PR DESCRIPTION
Put GTKGraph into a notebook (tabbed panel) so we can have multiple widgets down the bottom of the frame.
