### PR TITLE
correct bug where infobar shows when no torrent is selected

### DIFF
--- a/src/gtk/GtkTorrentInfoBar.cpp
+++ b/src/gtk/GtkTorrentInfoBar.cpp
@@ -25,7 +25,6 @@ GtkTorrentInfoBar::GtkTorrentInfoBar()
 */
 void GtkTorrentInfoBar::updateInfo(shared_ptr<gt::Torrent> selected)
 {
-	if(!selected) return;
 	vector<shared_ptr<gt::Torrent> > t = Application::getSingleton()->getCore()->getTorrents();
 
 	bool selectionExists = false;


### PR DESCRIPTION
The `updateInfo()` method does work on more than just the selected torrent, it also manages the visibility of the InfoBar.
