### PR TITLE
Fixes crashs when double clicking on an uninitialized torrent.

### DIFF
--- a/src/gtk/GtkMainWindow.cpp
+++ b/src/gtk/GtkMainWindow.cpp
@@ -11,10 +11,10 @@ GtkMainWindow::GtkMainWindow() :
 	this->set_default_size(800, 500);
 	Gtk::Paned *panel = Gtk::manage(new Gtk::Paned(Gtk::ORIENTATION_VERTICAL));
 
-	m_treeview = Gtk::manage(new GtkTorrentTreeView());
-	panel->pack1(*m_treeview);
+	m_infobar =  Gtk::manage(new GtkTorrentInfoBar());
+	m_treeview = Gtk::manage(new GtkTorrentTreeView(m_infobar));
 
-	m_infobar = Gtk::manage(new GtkTorrentInfoBar());
+	panel->pack1(*m_treeview);
 	panel->pack2(*m_infobar);
 
 	Glib::     signal_timeout().connect(sigc::mem_fun(*this, &GtkMainWindow::onSecTick), 1000);

--- a/src/gtk/GtkTorrentTreeView.cpp
+++ b/src/gtk/GtkTorrentTreeView.cpp
@@ -4,7 +4,7 @@
 /**
 * Sets up the tree view containing torrent information.
 */
-GtkTorrentTreeView::GtkTorrentTreeView()
+GtkTorrentTreeView::GtkTorrentTreeView(GtkTorrentInfoBar *InfoBar) : m_infobar(InfoBar)
 {
 	m_liststore = Gtk::ListStore::create(m_cols);
 	signal_button_press_event().connect(sigc::mem_fun(*this, &GtkTorrentTreeView::torrentView_onClick), false);
@@ -72,6 +72,7 @@ bool GtkTorrentTreeView::torrentView_onClick(GdkEventButton *event)
 		m_rcMenu->popup(event->button, event->time);
 	}
 
+	m_infobar->updateInfo(getFirstSelected());
 	return true;
 }
 
@@ -288,8 +289,14 @@ void GtkTorrentTreeView::stopView_onClick()
 */
 void GtkTorrentTreeView::openView_onClick()
 {
-	Glib::RefPtr<Gio::AppInfo> fileHandler = Gio::AppInfo::create_from_commandline("xdg-open", "If I knew I wouldn't ask, you turbonerd.", Gio::APP_INFO_CREATE_SUPPORTS_URIS);
 	shared_ptr<gt::Torrent> t = getFirstSelected();
+
+	if(t == nullptr)
+		return;
+	if(!t->getHandle().status().has_metadata)
+		return;
+
+	Glib::RefPtr<Gio::AppInfo> fileHandler = Gio::AppInfo::create_from_commandline("xdg-open", "If I knew I wouldn't ask, you turbonerd.", Gio::APP_INFO_CREATE_SUPPORTS_URIS);
 	t->getTextState();
 	auto files = t->getHandle().get_torrent_info().files();
 	string path = Application::getSingleton()->getCore()->getDefaultSavePath() + '/' + t->getHandle().get_torrent_info().file_at(0).path;

--- a/src/gtk/GtkTorrentTreeView.hpp
+++ b/src/gtk/GtkTorrentTreeView.hpp
@@ -12,6 +12,8 @@
 #include <gtkmm/menuitem.h>
 #include <gtkmm/treeviewcolumn.h>
 
+#include "GtkTorrentInfoBar.hpp"
+
 #include <Application.hpp>
 
 // Gtk Torrent Columns Section
@@ -67,7 +69,7 @@ private:
 	GtkTorrentColumns m_cols;
 	std::map<string, pair<string, string>> m_colors; // Associates a state with a background and foreground color.
 	Glib::RefPtr<Gtk::ListStore> m_liststore;
-
+	GtkTorrentInfoBar *m_infobar;
 	Gtk::Menu *m_rcMenu = Gtk::manage(new Gtk::Menu());
 	Gtk::CheckMenuItem *rcmItemSeq;
 
@@ -90,7 +92,7 @@ private:
 	void sequentialChange_onClick();
 
 public:
-	GtkTorrentTreeView();
+	GtkTorrentTreeView(GtkTorrentInfoBar *InfoBar);
 
 	void addCell(shared_ptr<gt::Torrent> &t);
 	void removeCell(unsigned index);


### PR DESCRIPTION
Also a timing issue.
When you select a torrent, the infobar could take up to 1 second before showing up.
