### PR TITLE
Added m_progress to InfoBar

### DIFF
--- a/src/gtk/GtkTorrentInfoBar.cpp
+++ b/src/gtk/GtkTorrentInfoBar.cpp
@@ -8,6 +8,8 @@ GtkTorrentInfoBar::GtkTorrentInfoBar()
 {
 	//TODO: better layout
 	m_notebook = Gtk::manage(new Gtk::Notebook());
+	m_stat_box = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL));
+	m_piece_box = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL));
 
 	m_title = Gtk::manage(new Gtk::Label());
 
@@ -16,7 +18,14 @@ GtkTorrentInfoBar::GtkTorrentInfoBar()
 	m_progress = Gtk::manage(new GtkBlockBar());
 	m_graph = Gtk::manage(new GtkGraph());
 
+    m_piece_box->pack_end(*m_progress, Gtk::PACK_EXPAND_WIDGET, 0);
+    m_progress->set_size_request(0, 50);
+
+
+    m_stat_box->add(*m_piece_box);
+
 	m_notebook->append_page(*m_graph, "Info Graph");
+	m_notebook->append_page(*m_stat_box, "Torrent Info");
 	this->pack_end(*m_notebook, Gtk::PACK_EXPAND_WIDGET, 5);
 }
 

--- a/src/gtk/GtkTorrentInfoBar.hpp
+++ b/src/gtk/GtkTorrentInfoBar.hpp
@@ -5,6 +5,7 @@
 #include <gtkmm/box.h>
 #include <gtkmm/notebook.h>
 #include <gtkmm/label.h>
+#include <gtkmm/listbox.h>
 
 #include <Application.hpp>
 
@@ -18,6 +19,8 @@ private:
 	Gtk::Label *m_title;
 	GtkGraph *m_graph;
 	Gtk::Notebook *m_notebook;
+	Gtk::Box *m_stat_box;
+	Gtk::Box *m_piece_box;
 public:
 	GtkTorrentInfoBar();
 	void updateInfo(shared_ptr<gt::Torrent> selected);


### PR DESCRIPTION
Added the m_progress bar found in GtkTorrentInfo bar to the actual info bar.
