### PR TITLE
Move uploaded/downloaded to torrent info tab

### DIFF
--- a/src/gtk/GtkTorrentInfoBar.cpp
+++ b/src/gtk/GtkTorrentInfoBar.cpp
@@ -26,25 +26,25 @@ GtkTorrentInfoBar::GtkTorrentInfoBar()
 
     m_stat_box->add(*m_piece_box);
 
-  	Gtk::Table *table_layout = Gtk::manage(new Gtk::Table(3, 2, false));
-  	table_layout->set_col_spacings(5);
+  	m_table_layout = Gtk::manage(new Gtk::Table(3, 2, false));
+  	m_table_layout->set_col_spacings(5);
 
-    Gtk::Label *down_total_label = Gtk::manage(new Gtk::Label());
-    down_total_label->set_markup("<b>Downloaded</b>");
-    Gtk::Label *down_total = Gtk::manage(new Gtk::Label("0"));
-    table_layout->attach(*down_total_label, 0, 1, 0, 1, Gtk::AttachOptions::SHRINK);
-    table_layout->attach(*(new Gtk::VSeparator()), 1, 2, 0, 1, Gtk::AttachOptions::SHRINK);
-    table_layout->attach(*down_total, 2, 3, 0, 1, Gtk::AttachOptions::SHRINK);
+    m_down_total_label = Gtk::manage(new Gtk::Label());
+    m_down_total_label->set_markup("<b>Downloaded</b>");
+    m_down_total = Gtk::manage(new Gtk::Label("0"));
+    m_table_layout->attach(*m_down_total_label, 0, 1, 0, 1, Gtk::AttachOptions::SHRINK);
+    m_table_layout->attach(*(new Gtk::VSeparator()), 1, 2, 0, 1, Gtk::AttachOptions::SHRINK);
+    m_table_layout->attach(*m_down_total, 2, 3, 0, 1, Gtk::AttachOptions::SHRINK);
 
-    Gtk::Label *up_total_label = Gtk::manage(new Gtk::Label());
-    up_total_label->set_markup("<b>Uploaded</b>");
-    Gtk::Label *up_total = Gtk::manage(new Gtk::Label("0"));
-    table_layout->attach(*up_total_label, 0, 1, 1, 2, Gtk::AttachOptions::SHRINK);
-    table_layout->attach(*(new Gtk::VSeparator()), 1, 2, 1, 2, Gtk::AttachOptions::SHRINK);
-    table_layout->attach(*up_total, 2, 3, 1, 2, Gtk::AttachOptions::SHRINK);
+    m_up_total_label = Gtk::manage(new Gtk::Label());
+    m_up_total_label->set_markup("<b>Uploaded</b>");
+    m_up_total = Gtk::manage(new Gtk::Label("0"));
+    m_table_layout->attach(*m_up_total_label, 0, 1, 1, 2, Gtk::AttachOptions::SHRINK);
+    m_table_layout->attach(*(new Gtk::VSeparator()), 1, 2, 1, 2, Gtk::AttachOptions::SHRINK);
+    m_table_layout->attach(*m_up_total, 2, 3, 1, 2, Gtk::AttachOptions::SHRINK);
 
     m_stat_box->pack_start(*(new Gtk::HSeparator()), Gtk::PACK_SHRINK);
-    m_stat_box->pack_start(*table_layout, Gtk::PACK_SHRINK);
+    m_stat_box->pack_start(*m_table_layout, Gtk::PACK_SHRINK);
 	m_notebook->append_page(*m_graph, "Info Graph");
 	m_notebook->append_page(*m_stat_box, "Torrent Info");
 	this->pack_end(*m_notebook, Gtk::PACK_EXPAND_WIDGET, 5);
@@ -75,6 +75,8 @@ void GtkTorrentInfoBar::updateInfo(shared_ptr<gt::Torrent> selected)
 			m_progress->setBlocks(t[selectedIndex]->getPieces());
 		m_title->set_text(t[selectedIndex]->getHandle().name());
 		m_graph->select(selectedIndex);
+		m_down_total->set_text(t[selectedIndex]->getTextTotalDownloaded());
+		m_up_total->set_text(t[selectedIndex]->getTextTotalUploaded());
 	}
 	else
 		this->set_visible(false);

--- a/src/gtk/GtkTorrentInfoBar.hpp
+++ b/src/gtk/GtkTorrentInfoBar.hpp
@@ -6,6 +6,7 @@
 #include <gtkmm/notebook.h>
 #include <gtkmm/label.h>
 #include <gtkmm/listbox.h>
+#include <gtkmm/table.h>
 
 #include <Application.hpp>
 
@@ -21,6 +22,12 @@ private:
 	Gtk::Notebook *m_notebook;
 	Gtk::Box *m_stat_box;
 	Gtk::Box *m_piece_box;
+
+    Gtk::Table *m_table_layout;
+    Gtk::Label *m_down_total_label;
+    Gtk::Label *m_down_total;
+    Gtk::Label *m_up_total_label;
+    Gtk::Label *m_up_total;
 public:
 	GtkTorrentInfoBar();
 	void updateInfo(shared_ptr<gt::Torrent> selected);

--- a/src/gtk/GtkTorrentTreeView.cpp
+++ b/src/gtk/GtkTorrentTreeView.cpp
@@ -116,16 +116,16 @@ void GtkTorrentTreeView::setupColumns()
 	Gtk::TreeViewColumn *col = nullptr;
 	Gtk::CellRendererProgress *cell = nullptr;
 
-	append_column("Queue", m_cols.m_col_queue);
+	append_column("#", m_cols.m_col_queue);
 	append_column("Age", m_cols.m_col_age);
 	append_column("ETA", m_cols.m_col_eta);
 	append_column("Name", m_cols.m_col_name);
 	append_column("Seed", m_cols.m_col_seeders);
 	append_column("Leech", m_cols.m_col_leechers);
-	append_column("Upload Speed", m_cols.m_col_ul_speed);
-	append_column("Download Speed", m_cols.m_col_dl_speed);
-	append_column("Uploaded", m_cols.m_col_ul_total);
-	append_column("Downloaded", m_cols.m_col_dl_total);
+	append_column("Up Speed", m_cols.m_col_ul_speed);
+	append_column("Down Speed", m_cols.m_col_dl_speed);
+	//append_column("Uploaded", m_cols.m_col_ul_total);
+	//append_column("Downloaded", m_cols.m_col_dl_total);
 	append_column("Size", m_cols.m_col_size);
 	append_column("Remains", m_cols.m_col_remaining);
 	append_column("Ratio", m_cols.m_col_dl_ratio);
@@ -152,8 +152,9 @@ void GtkTorrentTreeView::setupColumns()
 		c->set_clickable();
 		c->set_resizable();
 		c->set_reorderable();
-		c->set_fixed_width(96);
+		c->set_fixed_width(120);
 	}
+	this->get_column(0)->set_fixed_width(48);
 }
 
 /**
@@ -173,8 +174,8 @@ void GtkTorrentTreeView::addCell(shared_ptr<gt::Torrent> &t)
 	row[m_cols.m_col_name]       = t->getHandle().name();
 	row[m_cols.m_col_seeders]    = t->getTotalSeeders();
 	row[m_cols.m_col_leechers]   = t->getTotalLeechers();
-	row[m_cols.m_col_ul_total]   = t->getTextTotalUploaded();
-	row[m_cols.m_col_dl_total]   = t->getTextTotalDownloaded();
+	//row[m_cols.m_col_ul_total]   = t->getTextTotalUploaded();
+	//row[m_cols.m_col_dl_total]   = t->getTextTotalDownloaded();
 	row[m_cols.m_col_size]       = t->getTextSize();
 	row[m_cols.m_col_remaining]  = t->getTextRemaining();
 	row[m_cols.m_col_dl_ratio]   = t->getTextTotalRatio();


### PR DESCRIPTION
Add uploaded/downloaded data to torrent info tab
Make "Queue" tab smaller
Increase size of tabs since there are fewer of them
