### PR TITLE
Wip/hide actionless buttons

### DIFF
--- a/src/gtk/GtkMainWindow.cpp
+++ b/src/gtk/GtkMainWindow.cpp
@@ -37,8 +37,8 @@ GtkMainWindow::GtkMainWindow() :
 	header->set_title("gTorrent");
 
 	Gtk::VSeparator *separator0  = Gtk::manage(new Gtk::VSeparator());
-	Gtk::VSeparator *separator1  = Gtk::manage(new Gtk::VSeparator());
-	Gtk::VSeparator *separator2  = Gtk::manage(new Gtk::VSeparator());
+	//Gtk::VSeparator *separator1  = Gtk::manage(new Gtk::VSeparator());
+	//Gtk::VSeparator *separator2  = Gtk::manage(new Gtk::VSeparator());
 
 	btn_add_link   ->signal_clicked().connect(sigc::mem_fun(*this, &GtkMainWindow::onAddMagnetBtnClicked));
 	btn_add_torrent->signal_clicked().connect(sigc::mem_fun(*this, &GtkMainWindow::onAddBtnClicked));
@@ -82,6 +82,7 @@ GtkMainWindow::GtkMainWindow() :
 	add(*panel);
 	show_all();
 	btn_pause->hide();
+	btn_remove->hide();
 	m_infobar->set_visible(false);
 
 	// for some reason, the treeview start with its first element selected

--- a/src/gtk/GtkTorrentTreeView.cpp
+++ b/src/gtk/GtkTorrentTreeView.cpp
@@ -389,6 +389,7 @@ void GtkTorrentTreeView::onSelectionChanged(/*const Gtk::TreeModel::Path &path, 
 	{
 		m_parent->btn_pause ->hide();
 		m_parent->btn_resume->hide();
+		m_parent->btn_remove->hide();
 		return;
 	}
 
@@ -401,7 +402,7 @@ void GtkTorrentTreeView::onSelectionChanged(/*const Gtk::TreeModel::Path &path, 
 
 	m_parent->btn_pause ->set_visible(startedTorrents != 0);
 	m_parent->btn_resume->set_visible( pausedTorrents != 0);
-
+	m_parent->btn_remove ->set_visible();
 }
 
 // columns are saved in a single settings, looking like this:


### PR DESCRIPTION
I've based this on the principle of least astonishment.

We might want the pause/remove buttons to have action on all torrents when none is selected, however this warrants further thought/discussion, and I think this is a good solution for the interim.
